### PR TITLE
Add java 7 for GATK

### DIFF
--- a/tasks/install_system_packages.yml
+++ b/tasks/install_system_packages.yml
@@ -1,6 +1,9 @@
 - name: Install ppa for latest git
   apt_repository: repo='ppa:git-core/ppa' state=present
 
+- name: Install ppa for java 7
+  apt_repository: repo='ppa:openjdk-r/ppa' state=present
+
 - name: Apt autoremove unused dependencies
   # apt: autoremove=yes - won't be supported till ansible 2.1
   shell: apt-get autoremove -y

--- a/tasks/install_tool_packages.yml
+++ b/tasks/install_tool_packages.yml
@@ -7,6 +7,8 @@
     - tabix
     # https://trello.com/c/7x9svF7x/382-bar-chart-tool-error
     - gnuplot
+    # GATK 1.4 and 2.8 needs Java 7
+    - openjdk-7-jdk
 
 - name: "Preinstall common packages (makes jupyterhub install faster)"
   apt: name={{ item }}


### PR DESCRIPTION
GATK 1.4 and 2.8 both need Java 7 and the image currently only has Java 8.

At the moment, trying to install Oracle's Java 7 gives me a 404 error for the tar file, so I went with OpenJDK instead.